### PR TITLE
Public IP Address is a network Attribute

### DIFF
--- a/hook.xml
+++ b/hook.xml
@@ -6,7 +6,7 @@
     <hook type="cdentry">
         <identifier>cd_lastpublicip</identifier>
         <translation>41011</translation>
-        <category>other</category>
+        <category>network</category>
         <available>lastpublicip</available>
     </hook>
 </hookstore>


### PR DESCRIPTION
Currently, the public IP address is stored in the `other` category. A better category fit already exists. This change moves the public IP to the `network` category